### PR TITLE
Update chromix-server example to include --host

### DIFF
--- a/web/index.ascii
+++ b/web/index.ascii
@@ -102,7 +102,7 @@ devices outside of your local machine, set the bind address:
 
 [source, sh]
 ----
-node script/server.js --host=0.0.0.0
+chromix-server --host=0.0.0.0
 ----
 ****
 


### PR DESCRIPTION
Chromix-server supports both --host and --port so the docs aren't up to date for npm installed chromix