### PR TITLE
remove deprecated sys.print and use console.log

### DIFF
--- a/script/server.coffee
+++ b/script/server.coffee
@@ -26,8 +26,8 @@ if args.help
 # #####################################################################
 # Utilities ...
 
-print = require('sys').print
-echo  = (msg) -> print "#{msg}\n"
+print = console.log
+echo  = (msg) -> print "#{msg}"
 
 # #####################################################################
 # Web socket and handler ...


### PR DESCRIPTION
This fixes issue #15 - replaces sys.print with console.log to prevent debug output.

I updated the snapshots locally but didn't add them to this commit because my Coffeescript version is quite a bit newer which causes some variable name changes. I thought you may want to build the new snapshots yourself, but I can rebase them here if you'd like.