### PR TITLE
Stay on WS 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
    "licenses" : [ {"type" : "MIT" } ],  
    "engines" : { "node" : ">=0.4" },
    "keywords": [ "chrome", "chromi", "extension", "cli", "command", "line" ],
-   "dependencies": { "ws" :  "*", "optimist" :  "*" },
+   "dependencies": { "ws" :  "1.*", "optimist" :  "*" },
    "bin": {
       "chromix": "./snapshots/chromix.js",
       "chromix-server": "./snapshots/server.js"


### PR DESCRIPTION
WS 2.x seems to break things so if you could put up a new release with this, that'd be great; the lack of foreground control is preventing the use of chromix-too :)